### PR TITLE
Updated to Python v3.13.12 and Debian to trixie (Aug 2025)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-ARG PYTHON_VERSION=3.9
+ARG PYTHON_VERSION=3.13.12
 
 # use the latest version of python
-FROM python:${PYTHON_VERSION}-bullseye
+FROM python:${PYTHON_VERSION}-trixie
 
 # get some credit
 LABEL maintainer="powen@renci.org"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 TranslatorSRI
+Copyright (c) 2022, 2026 TranslatorSRI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
If I'm understanding the GitHub action correctly, if we publish this in a branch named `3.13.12`, it should release the right version of Python in Docker. But I figured we might as well update the Debian version and the version in the file as well to avoid confusion.